### PR TITLE
requestAnimationFrame is better than setTimeout

### DIFF
--- a/todomvc-benchmark/resources/benchmark-runner.js
+++ b/todomvc-benchmark/resources/benchmark-runner.js
@@ -110,12 +110,12 @@ BenchmarkRunner.prototype._runTest = function(suite, testFunction, prepareReturn
     var syncTime = endTime - startTime;
 
     var startTime = now();
-    setTimeout(function () {
-        setTimeout(function () {
+    window.requestAnimationFrame(function () {
+        window.requestAnimationFrame(function () {
             var endTime = now();
             callback(syncTime, endTime - startTime);
-        }, 0)
-    }, 0);
+        })
+    });
 }
 
 function BenchmarkState(suites) {


### PR DESCRIPTION
Hi,

[Mithril document's auto redraw system document](http://lhorie.github.io/mithril/auto-redrawing.html) says, it uses requestAnimationFrame instead of setTimeout. Callback function of requestAnimationFrame is called much slower than setTimeout's one with 0. I think your benchmark can't check actual async process load.

Original benchmark said Mithril was much faster than other frameworks (x21 than React), but rquestAnimationFrame version becomes x5. It is closer number to Mithril's benchmark on its website. I think it is more equal.